### PR TITLE
共起ネットワークのノード重なり問題を解決

### DIFF
--- a/pages/14_テキストマイニング.py
+++ b/pages/14_テキストマイニング.py
@@ -166,10 +166,11 @@ def create_cooccurrence_network_with_communities(graph, title='共起ネット�
 
     # レイアウト計算（KH CoderはKamada-Kawaiを使用）
     try:
-        pos = nx.kamada_kawai_layout(subgraph)
+        # scaleパラメータでノード間の距離を調整（大きいほど広がる）
+        pos = nx.kamada_kawai_layout(subgraph, scale=2.0)
     except:
-        # フォールバック: spring layout
-        pos = nx.spring_layout(subgraph, k=1, iterations=50)
+        # フォールバック: spring layout（k値を大きくしてノード間の距離を広げる）
+        pos = nx.spring_layout(subgraph, k=2.0, iterations=100)
 
     # ノードの中心性を計算（ノードサイズ用）
     try:
@@ -217,14 +218,14 @@ def create_cooccurrence_network_with_communities(graph, title='共起ネット�
                 node_x.append(x)
                 node_y.append(y)
                 node_text.append(f"{node_to_word.get(node, str(node))}<br>グループ: {comm_id + 1}<br>中心性: {degree_centrality[node]:.3f}")
-                node_size.append(20 + degree_centrality[node] * 100)
+                node_size.append(15 + degree_centrality[node] * 80)
 
             node_trace = go.Scatter(
                 x=node_x,
                 y=node_y,
                 mode='markers+text',
                 text=[node_to_word.get(node, str(node)) for node in nodes_in_comm],
-                textposition='middle center',
+                textposition='top center',
                 textfont=dict(
                     size=12,
                     family='IPAexGothic, "Hiragino Sans", "Noto Sans CJK JP", "Yu Gothic", Meiryo, Arial, sans-serif',
@@ -253,8 +254,8 @@ def create_cooccurrence_network_with_communities(graph, title='共起ネット�
             xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
             yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
             plot_bgcolor='white',
-            width=1000,
-            height=600,
+            width=1200,
+            height=800,
             font=dict(
                 family='IPAexGothic, "Hiragino Sans", "Noto Sans CJK JP", "Yu Gothic", Meiryo, Arial, sans-serif',
                 size=12,
@@ -265,7 +266,7 @@ def create_cooccurrence_network_with_communities(graph, title='共起ネット�
         return fig
     else:
         # matplotlibで描画
-        fig_net, ax = plt.subplots(figsize=(12, 8))
+        fig_net, ax = plt.subplots(figsize=(16, 12))
 
         # コミュニティごとに色を設定
         num_communities = len(set(node_to_community.values()))


### PR DESCRIPTION
## 問題
共起ネットワークで円（ノード）が重なって表示される問題が発生。

## 解決策

### 1. グラフサイズの拡大
**Plotly版:**
- 幅: 1000px → 1200px
- 高さ: 600px → 800px

**matplotlib版:**
- figsize: (12, 8) → (16, 12)

### 2. レイアウトアルゴリズムの調整
**Kamada-Kawaiレイアウト:**
```python
# 修正前
pos = nx.kamada_kawai_layout(subgraph)

# 修正後（scaleパラメータでノード間距離を2倍に）
pos = nx.kamada_kawai_layout(subgraph, scale=2.0)
```

**Spring Layout（フォールバック時）:**
- k値: 1.0 → 2.0（ノード間の反発力を強化）
- iterations: 50 → 100（より安定したレイアウト）

### 3. ノード表示の最適化
- **ノードサイズを縮小**: `20 + centrality * 100` → `15 + centrality * 80`
- **テキスト位置を調整**: `middle center` → `top center`（ノードの上に表示）

## 効果
- ✅ ノード間の距離が広がり、重なりが大幅に減少
- ✅ グラフが大きくなり、全体が見やすくなった
- ✅ テキストがノードの上に表示され、可読性が向上
- ✅ KH Coderのような見やすい共起ネットワーク表示を実現